### PR TITLE
Don't set maxAge cookie on ping

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -264,7 +264,7 @@ class App extends Component {
 					this.setState({loading: false, sessionsLimitReached: true});
 				} else {
 					this.timeout = response ? parseInt(response.timeRemaining * 1000) : 0;
-					cookies.set(cookieName, uuid, { path: '/', maxAge: this.timeout });
+					// cookies.set(cookieName, uuid, { path: '/', maxAge: this.timeout });
 					if (!ping) {
 						this.setState({loading: false, uuid: uuid});
 					}


### PR DESCRIPTION
Setting the cookie changes the page state and causes a re-render

Fixes #162 