### PR TITLE
Fix regression in b855e9d

### DIFF
--- a/src/components/common/ViewerSidebar.jsx
+++ b/src/components/common/ViewerSidebar.jsx
@@ -226,9 +226,9 @@ class ViewerSidebar extends Component {
                 );
             console.log(activeFeatures[i]);
             if (activeFeatures[i] && activeFeatures[i].metadata) {
+                let image = '';
                 let md = activeFeatures[i].metadata;
                 if (md.motifName != 'NA.png' && !this.state.imageErrored) {
-                    let image = '';
                     if (this.state.imageErrored) {
                         image = md.motifName ? (
                             <img


### PR DESCRIPTION
This fixes a regression introduced in b855e9d whereby an `image` variable is not in scope which crashes the application.