### PR TITLE
Bugfix/302 increase grpc message size limits

### DIFF
--- a/opt/scopeserver/bindserver/package.json
+++ b/opt/scopeserver/bindserver/package.json
@@ -21,7 +21,7 @@
   "scripts": {},
   "dependencies": {
     "grpc": "^1.0.1",
-    "grpc-bus": "https://github.com/gabrielgrant/grpc-bus/releases/download/v1.0.1-dev5/grpc-bus-1.0.1-dev5.tgz",
+    "grpc-bus": "https://github.com/aertslab/grpc-bus/releases/download/v1.0.2/grpc-bus-1.0.2.tgz",
     "protobufjs": "^5.0.2",
     "rsvp": "^3.3.3",
     "ws": "^7.0.0"

--- a/opt/scopeserver/dataserver/modules/gserver/GServer.py
+++ b/opt/scopeserver/dataserver/modules/gserver/GServer.py
@@ -951,7 +951,10 @@ class SCope(s_pb2_grpc.MainServicer):
 
 def serve(run_event, config: Dict[str, Any]) -> None:
     SCope.app_mode = config["app_mode"]
-    server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=10), options=[
+        ('grpc.max_send_message_length', -1),
+        ('grpc.max_receive_message_length', -1)
+    ])
     scope = SCope(config=config)
     s_pb2_grpc.add_MainServicer_to_server(scope, server)
     server.add_insecure_port("[::]:{0}".format(config["gPort"]))

--- a/opt/scopeserver/dataserver/modules/gserver/GServer.py
+++ b/opt/scopeserver/dataserver/modules/gserver/GServer.py
@@ -951,10 +951,10 @@ class SCope(s_pb2_grpc.MainServicer):
 
 def serve(run_event, config: Dict[str, Any]) -> None:
     SCope.app_mode = config["app_mode"]
-    server = grpc.server(futures.ThreadPoolExecutor(max_workers=10), options=[
-        ('grpc.max_send_message_length', -1),
-        ('grpc.max_receive_message_length', -1)
-    ])
+    server = grpc.server(
+        futures.ThreadPoolExecutor(max_workers=10),
+        options=[("grpc.max_send_message_length", -1), ("grpc.max_receive_message_length", -1)],
+    )
     scope = SCope(config=config)
     s_pb2_grpc.add_MainServicer_to_server(scope, server)
     server.add_insecure_port("[::]:{0}".format(config["gPort"]))


### PR DESCRIPTION
This removes the limit on GRPC messages.

A fresh install might be needed, or the node_modules and package_lock.json files might need to be deleted from both the root directory AND the bindserver directory.

@dweemx Can you test with some larger loom files? My testing with a hacked GServer worked, but would be good to test on something real.