### PR TITLE
Fix non collapsed descriptions

### DIFF
--- a/opt/scopeserver/dataserver/modules/gserver/GServer.py
+++ b/opt/scopeserver/dataserver/modules/gserver/GServer.py
@@ -324,6 +324,8 @@ class SCope(s_pb2_grpc.MainServicer):
     def setAnnotationName(self, request, context):
         loom = self.lfh.get_loom(loom_file_path=Path(request.loomFilePath))
         success = loom.rename_annotation(request.clusteringID, request.clusterID, request.newAnnoName)
+        if success:
+            self.get_features.cache_clear()
         return s_pb2.SetAnnotationNameReply(success=success)
 
     def setLoomHierarchy(self, request, context):
@@ -336,6 +338,8 @@ class SCope(s_pb2_grpc.MainServicer):
         if not self.dfh.confirm_orcid_uuid(request.orcidInfo.orcidID, request.orcidInfo.orcidUUID):
             return s_pb2.setColabAnnotationDataReply(success=False, message="Could not confirm user!")
         success, message = loom.add_collab_annotation(request, self.config["dataHashSecret"])
+        if success:
+            self.get_features.cache_clear()
         return s_pb2.setColabAnnotationDataReply(success=success, message=message)
 
     def addNewClustering(self, request, context):
@@ -343,6 +347,8 @@ class SCope(s_pb2_grpc.MainServicer):
         if not self.dfh.confirm_orcid_uuid(request.orcidInfo.orcidID, request.orcidInfo.orcidUUID):
             return s_pb2.AddNewClusteringReply(success=False, message="Could not confirm user!")
         success, message = loom.add_user_clustering(request)
+        if success:
+            self.get_features.cache_clear()
         return s_pb2.AddNewClusteringReply(success=success, message=message)
 
     def voteAnnotation(self, request, context):

--- a/opt/scopeserver/dataserver/utils/search.py
+++ b/opt/scopeserver/dataserver/utils/search.py
@@ -134,7 +134,7 @@ def create_feature_description(
     aggregated_matches: Dict[Tuple[str, str], List[str]],
     features: Dict[Tuple[str, str], str],
     feature_types: Dict[Tuple[str, str], str],
-) -> Dict[Tuple[str, str], str]:
+) -> Tuple[Dict[Tuple[str, str], str], Dict[Tuple[str, str], str], Dict[Tuple[str, str], str]]:
     """
     Generate descriptions for final results.
 
@@ -165,6 +165,8 @@ def create_feature_description(
                 category_name = features[k]
                 category_type = feature_types[k]
                 desc_key = (category_name, category_type)
+                features[desc_key] = features[k]
+                feature_types[desc_key] = feature_types[k]
             else:
                 is_cluster = False
                 category_name = k[0]
@@ -186,7 +188,7 @@ def create_feature_description(
 
     final_descriptions = {k: ", ".join(v) for (k, v) in descriptions.items()}
 
-    return final_descriptions
+    return final_descriptions, features, feature_types
 
 
 def get_final_feature_and_type(
@@ -247,7 +249,7 @@ def get_search_results(search_term: str, loom: Loom, data_hash_secret: str) -> D
     matches = find_matches(search_term, loom.ss.search_space_dict)
     aggregated_matches = aggregate_matches(matches)
     features, feature_types = get_final_feature_and_type(loom, aggregated_matches, data_hash_secret)
-    descriptions = create_feature_description(aggregated_matches, features, feature_types)
+    descriptions, features, feature_types = create_feature_description(aggregated_matches, features, feature_types)
 
     final_res = {
         "feature": [features[k] for k in descriptions],

--- a/opt/scopeserver/dataserver/utils/search.py
+++ b/opt/scopeserver/dataserver/utils/search.py
@@ -126,7 +126,7 @@ def aggregate_matches(matches: List[MatchResult]) -> Dict[ResultTypePair, List[s
 
     aggregated_matches: Dict[ResultTypePair, List[str]] = OrderedDict()
     for match in matches:
-        key = (match.result, match.search_space_match.element_type)
+        key = ResultTypePair(match.result, match.search_space_match.element_type)
         if key not in aggregated_matches.keys():
             aggregated_matches[key] = [match.search_space_match.element]
         else:
@@ -171,7 +171,7 @@ def create_feature_description(
                 is_cluster = True
                 category_name = features[k]
                 category_type = feature_types[k]
-                desc_key = (category_name, category_type)
+                desc_key = ResultTypePair(category_name, category_type)
                 features[desc_key] = features[k]
                 feature_types[desc_key] = feature_types[k]
             else:

--- a/opt/scopeserver/dataserver/utils/search_space.py
+++ b/opt/scopeserver/dataserver/utils/search_space.py
@@ -109,7 +109,8 @@ class SearchSpace:
                 for annotation in annotations:
                     key = SSKey(annotation, element_type)
                     if (annotation, element_type) in self.search_space_dict.keys():
-                        self.search_space_dict[key].append(f"{clusteringID}_{clusterID}")
+                        if f"{clusteringID}_{clusterID}" not in self.search_space_dict[key]:
+                            self.search_space_dict[key].append(f"{clusteringID}_{clusterID}")
                     else:
                         self.search_space_dict[key] = [f"{clusteringID}_{clusterID}"]
 

--- a/opt/scopeserver/dataserver/utils/search_space.py
+++ b/opt/scopeserver/dataserver/utils/search_space.py
@@ -9,7 +9,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-CURRENT_SS_VERISON = 1
+CURRENT_SS_VERISON = 2
 
 
 class SSKey(NamedTuple):


### PR DESCRIPTION
This fixes the issue with duplicated search results, where descriptions are not collapsed

TODO:

- [x] Track down weird (extra) bug with double annotation results
  - Searching for a cluster annotation results in the annotation being doubled in the cluster description. Likely due to pdating the search space when adding a new annotation