### PR TITLE
Disable resize detection in App.jsx

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -189,11 +189,6 @@ class App extends Component {
                         path='/:uuid/:loom?/:page?'
                         render={({ history }) => (
                             <Segment className='parentView'>
-                                <ReactResizeDetector
-                                    handleHeight
-                                    skipOnMount
-                                    onResize={this.onResize.bind(this)}
-                                />
                                 <AppHeader
                                     toggleSidebar={this.toggleSidebar.bind(
                                         this
@@ -575,10 +570,6 @@ class App extends Component {
             action: 'toggle sidebar',
             label: state ? 'on' : 'off',
         });
-    }
-
-    onResize() {
-        this.forceUpdate();
     }
 
     restoreSession(ip, uuid, permalink) {


### PR DESCRIPTION
This fixes using multi-loom viewing in the compare tab in new versions of chrome and firefox.

Not sure what caused the bug to appear, but the resize detector was being triggered resulting in a re-render and resetting the page when switching to multi-loom.