### PR TITLE
Test client result type

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,7 @@
         "dev": "webpack serve --config config/webpack.dev.js",
         "build": "webpack --config config/webpack.prod.js",
         "start": "npm run dev",
-        "test": "jest",
+        "test": "jest --coverage",
         "lint-fix": "eslint --fix 'src/**/*.{ts,jsx,tsx}'",
         "lint": "tsc --noEmit && eslint 'src/**/*.{ts,jsx,tsx}'",
         "bundle-size-analyse": "webpack --config config/webpack.dev.js --profile --json > stats.json"
@@ -197,6 +197,14 @@
         },
         "globals": {
             "__TEST_ONLY__": true
+        },
+        "coverageThreshold": {
+            "global": {
+                "branches": 18,
+                "functions": 21,
+                "lines": 36,
+                "statements": 38
+            }
         }
     }
 }

--- a/client/src/api/fetch.test.ts
+++ b/client/src/api/fetch.test.ts
@@ -1,7 +1,7 @@
 import 'jest';
 
 import { fetchJson } from './fetch';
-import { Result, is_success, with_default, is_error, match } from '../result';
+import { Result, withDefault, isError, match } from '../result';
 
 type Post = {
     id: number;
@@ -44,7 +44,7 @@ describe('Fetches JSON', () => {
             'https://a.test.com/posts/1'
         );
 
-        const post: Post = with_default(defaultPost(), result);
+        const post: Post = withDefault(defaultPost(), result);
 
         expect(post.id).toBe(1);
         expect(post.title).toBe('A test');
@@ -65,10 +65,10 @@ describe('Fetches JSON', () => {
             'https://a.test.com/posts/1'
         );
 
-        expect(is_error(result)).toBe(true);
+        expect(isError(result)).toBe(true);
 
         match(
-            (post: Post): void => fail('Should not get here'),
+            (_post: Post): void => fail('Should not get here'),
             (msg: string): void => expect(msg).toBe('API is down'),
             result
         );

--- a/client/src/components/GProfiler/sagas.test.ts
+++ b/client/src/components/GProfiler/sagas.test.ts
@@ -1,0 +1,78 @@
+/**
+ * This module tests Sagas for GProfiler
+ */
+import 'jest';
+
+import { call, put } from 'redux-saga/effects';
+import { cloneableGenerator } from '@redux-saga/testing-utils';
+
+import { fetchJson } from '../../api/fetch';
+import { success, error } from '../../result';
+
+import { fetchAvailableOrganisms } from './sagas';
+import { setAvailableOrganisms, setError } from './actions';
+import { GPROFILER_API_ENDPOINT__AVAILABLE_ORGANISMS } from './constants';
+
+const exampleResults = [
+    {
+        display_name: 'test1',
+        id: '0',
+        scientific_name: 'sci test 1',
+        version: '0',
+    },
+    {
+        display_name: 'test2',
+        id: '1',
+        scientific_name: 'sci test 2',
+        version: '34',
+    },
+];
+
+describe('Query API side-effect', () => {
+    // @ts-ignore
+    const generator = cloneableGenerator(fetchAvailableOrganisms)();
+
+    it('Calls the GProfiler API', () => {
+        const result = generator.next().value;
+        expect(result).toEqual(
+            call(fetchJson, GPROFILER_API_ENDPOINT__AVAILABLE_ORGANISMS)
+        );
+    });
+
+    describe('...and if the request was successful', () => {
+        let clone;
+
+        beforeAll(() => {
+            clone = generator.clone();
+        });
+
+        it('Raises a SET_AVAILABLE_ORGANISMS action', () => {
+            const result = clone.next(success(exampleResults)).value;
+            expect(result).toEqual(put(setAvailableOrganisms(exampleResults)));
+        });
+
+        it('performs no further work', () => {
+            expect(clone.next().done).toBe(true);
+        });
+    });
+
+    describe('...and if the request fails', () => {
+        let clone;
+
+        beforeAll(() => {
+            clone = generator.clone();
+        });
+
+        it('Raises a SET_ERROR action', () => {
+            const msg = 'Error message';
+            const result = clone.next(error(msg)).value;
+            expect(result).toEqual(
+                put(setError(`Unable to fetch list of organisms: ${msg}`))
+            );
+        });
+
+        it('performs no further work', () => {
+            expect(clone.next().done).toBe(true);
+        });
+    });
+});

--- a/client/src/components/GProfiler/sagas.ts
+++ b/client/src/components/GProfiler/sagas.ts
@@ -2,7 +2,7 @@ import { put, takeLatest, call } from 'redux-saga/effects';
 
 import { fetchJson } from '../../api/fetch';
 import * as t from './actionTypes';
-import { Result, map, is_success } from '../../result';
+import { Result, match } from '../../result';
 
 import * as c from './constants';
 import { GProfilerOrganism } from './model';
@@ -14,15 +14,18 @@ function* fetchAvailableOrganisms() {
         c.GPROFILER_API_ENDPOINT__AVAILABLE_ORGANISMS
     );
 
-    if (is_success(organisms)) {
-        yield put(Action.setAvailableOrganisms(organisms.value));
-    } else {
-        yield put(Action.setError('Unable to fetch list of organisms'));
-    }
+    yield put(
+        match<Array<GProfilerOrganism>, string, Action.GProfilerAction>(
+            (orgs) => Action.setAvailableOrganisms(orgs),
+            (err) =>
+                Action.setError(`Unable to fetch list of organisms: ${err}`),
+            organisms
+        )
+    );
 }
 
 function* fetchAvailableOrganismsSaga() {
     yield takeLatest(t.FETCH_AVAILABLE_ORGANISMS, fetchAvailableOrganisms);
 }
 
-export { fetchAvailableOrganismsSaga };
+export { fetchAvailableOrganismsSaga, fetchAvailableOrganisms };

--- a/client/src/result.test.ts
+++ b/client/src/result.test.ts
@@ -1,0 +1,63 @@
+import 'jest';
+
+import {
+    error,
+    success,
+    isError,
+    isSuccess,
+    withDefault,
+    match,
+    map,
+    mapError,
+} from './result';
+
+describe('Check constructors', () => {
+    it('Can create Success', () => {
+        expect(success(5)).toEqual({ kind: 'Success', value: 5 });
+    });
+
+    it('Can create Error', () => {
+        expect(error('error')).toEqual({ kind: 'Error', error: 'error' });
+    });
+
+    it('Can check if a Result is a success', () => {
+        expect(isSuccess(success(0))).toBe(true);
+        expect(isError(success(1))).toBe(false);
+    });
+
+    it('Can check if a Result is an error', () => {
+        expect(isError(error(1))).toBe(true);
+        expect(isSuccess(error(0))).toBe(false);
+    });
+});
+
+describe('Operations on Result', () => {
+    it('Can have a default value', () => {
+        expect(withDefault('hello', success('world'))).toEqual('world');
+        expect(withDefault('hello', error(5))).toBe('hello');
+    });
+
+    it('Can match either side of a result', () => {
+        const ok_op = (x) => x;
+        const err_op = (y) => `Error: ${y}`;
+
+        expect(match(ok_op, err_op, success(5))).toBe(5);
+        expect(match(ok_op, err_op, error('test'))).toBe('Error: test');
+    });
+
+    it('Can map the Success side', () => {
+        expect(map((v) => v.length, success('test'))).toEqual(success(4));
+        expect(map((v: string) => v.length, error('test'))).toEqual(
+            error('test')
+        );
+    });
+
+    it('Can map the error side', () => {
+        expect(mapError((e) => `Error ${e}`, error(5))).toEqual(
+            error('Error 5')
+        );
+        expect(mapError((e: number) => `Error ${e}`, success('test'))).toEqual(
+            success('test')
+        );
+    });
+});

--- a/client/src/result.ts
+++ b/client/src/result.ts
@@ -24,16 +24,16 @@ export function error<T>(err: T): ErrorT<T> {
     };
 }
 
-export function is_success<S, E>(result: Result<S, E>): result is SuccessT<S> {
+export function isSuccess<S, E>(result: Result<S, E>): result is SuccessT<S> {
     return result.kind === 'Success';
 }
 
-export function is_error<S, E>(result: Result<S, E>): result is ErrorT<E> {
+export function isError<S, E>(result: Result<S, E>): result is ErrorT<E> {
     return result.kind === 'Error';
 }
 
-export function with_default<S, E>(defaultval: S, result: Result<S, E>): S {
-    if (is_success(result)) {
+export function withDefault<S, E>(defaultval: S, result: Result<S, E>): S {
+    if (isSuccess(result)) {
         return result.value;
     }
 
@@ -41,11 +41,11 @@ export function with_default<S, E>(defaultval: S, result: Result<S, E>): S {
 }
 
 export function match<S, E, V>(
-    ok: (val: S) => V,
-    err: (val: E) => V,
+    ok: (_val: S) => V,
+    err: (_val: E) => V,
     result: Result<S, E>
 ): V {
-    if (is_success(result)) {
+    if (isSuccess(result)) {
         return ok(result.value);
     } else {
         return err(result.error);
@@ -53,20 +53,20 @@ export function match<S, E, V>(
 }
 
 export function map<S, T, E>(
-    fn: (val: S) => T,
+    fn: (_val: S) => T,
     result: Result<S, E>
 ): Result<T, E> {
-    if (is_success(result)) {
+    if (isSuccess(result)) {
         return success(fn(result.value));
     }
     return result;
 }
 
-export function map_error<S, E, F>(
-    fn: (val: E) => F,
+export function mapError<S, E, F>(
+    fn: (_val: E) => F,
     result: Result<S, E>
 ): Result<S, F> {
-    if (is_error(result)) {
+    if (isError(result)) {
         return error(fn(result.error));
     }
 


### PR DESCRIPTION
Also:
* slightly change the API to follow the naming convention. Thanks @dweemx 
* Adds tests for GProfiler Sagas
* Fixes use of the Result type in the GProfiler component
* Adds minimum test coverage values for the client