### PR TITLE
Build the client in production configuration in CI

### DIFF
--- a/.github/workflows/continuous-integration-client.yml
+++ b/.github/workflows/continuous-integration-client.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Build production application
         run: |
           npm build
+        working-directory: ${{ env.working-directory }}
       - name: Lint
         run: |
           npm run lint

--- a/.github/workflows/continuous-integration-client.yml
+++ b/.github/workflows/continuous-integration-client.yml
@@ -33,7 +33,7 @@ jobs:
         working-directory: ${{ env.working-directory }}
       - name: Build production application
         run: |
-          npm build
+          npm run build
         working-directory: ${{ env.working-directory }}
       - name: Lint
         run: |

--- a/.github/workflows/continuous-integration-client.yml
+++ b/.github/workflows/continuous-integration-client.yml
@@ -31,6 +31,9 @@ jobs:
         run: |
           npm audit --audit-level=moderate
         working-directory: ${{ env.working-directory }}
+      - name: Build production application
+        run: |
+          npm build
       - name: Lint
         run: |
           npm run lint


### PR DESCRIPTION
This is to catch build failures in CI. This is prompted by several recent instances of build failures not being noticed in CI