### PR TITLE
Disable pylint W1203

### DIFF
--- a/.github/workflows/continuous-integration-server.yml
+++ b/.github/workflows/continuous-integration-server.yml
@@ -44,7 +44,7 @@ jobs:
 
             - name: Run pylint
               run: |
-                  ${HOME}/.poetry/bin/poetry run pylint-fail-under --fail_under "7.3" --rcfile pyproject.toml scopeserver main.py
+                  ${HOME}/.poetry/bin/poetry run pylint-fail-under --fail_under "7.75" --rcfile pyproject.toml scopeserver main.py
               working-directory: ${{ env.working-directory }}
 
             - name: Run black

--- a/.github/workflows/continuous-integration-server.yml
+++ b/.github/workflows/continuous-integration-server.yml
@@ -44,7 +44,7 @@ jobs:
 
             - name: Run pylint
               run: |
-                  ${HOME}/.poetry/bin/poetry run pylint-fail-under --fail_under "7.75" --rcfile pyproject.toml scopeserver main.py
+                  ${HOME}/.poetry/bin/poetry run pylint-fail-under --fail_under "7.74" --rcfile pyproject.toml scopeserver main.py
               working-directory: ${{ env.working-directory }}
 
             - name: Run black

--- a/.github/workflows/continuous-integration-server.yml
+++ b/.github/workflows/continuous-integration-server.yml
@@ -44,7 +44,7 @@ jobs:
 
             - name: Run pylint
               run: |
-                  ${HOME}/.poetry/bin/poetry run pylint-fail-under --fail_under "7.5" --rcfile pyproject.toml scopeserver main.py
+                  ${HOME}/.poetry/bin/poetry run pylint-fail-under --fail_under "7.3" --rcfile pyproject.toml scopeserver main.py
               working-directory: ${{ env.working-directory }}
 
             - name: Run black

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -68,6 +68,7 @@ dev-script = 'scopeserver:run'
 
 [tool.pylint.'MESSAGES CONTROL']
 max-line-length = '120'
+disable = 'W1203'
 
 [tool.black]
 line-length = 120


### PR DESCRIPTION
https://pycodequ.al/docs/pylint-messages/w1203-logging-fstring-interpolation.html
PyLint warns about not using lazy formatting for logging because
formatting messages that aren't printed is wasteful. This is
not interesting for our purposes and makes pylint output more
noisy than necessary.